### PR TITLE
The Sword in the Stone (1963)

### DIFF
--- a/The Sword in the Stone
+++ b/The Sword in the Stone
@@ -1,0 +1,23 @@
+{
+  "name": "The Sword in the Stone",
+  "year": 1963,
+  "runtime": 115,
+  "categories": [
+    "action",
+    "adventure",
+    "Animation"
+  ],
+  "release-date": "25 December 1963",
+  "director": " Wolfgang Reitherman",
+  "writer": [
+    " Bill Peet (story)",
+    "T.H. White (based on the book by)",
+    
+  ],
+  "actors": [
+    " Rickie Sorensen",
+    " Sebastian Cabot",
+    " Karl Swenson"
+  ],
+  "storyline": "A poor boy named Arthur learns the power of love, kindness, knowledge and bravery with the help of a wizard called Merlin in the path to become one of the most beloved kings in English history"
+}


### PR DESCRIPTION
The Sword in the Stone (1963).
Director: Wolfgang Reitherman
Writers: Bill Peet (story), T.H. White (based on the book by)
Stars: Rickie Sorensen, Sebastian Cabot, Karl Swenson 
